### PR TITLE
Implement read and write

### DIFF
--- a/src/Stream/Stream.php
+++ b/src/Stream/Stream.php
@@ -1,19 +1,22 @@
 <?php
 namespace Icicle\Psr7Bridge\Stream;
 
-use Icicle\Http\Exception\LogicException;
 use Icicle\Loop;
 use Icicle\Stream\ReadableStreamInterface;
+use Icicle\Stream\SeekableStreamInterface;
+use Icicle\Stream\StreamInterface;
 use Icicle\Stream\WritableStreamInterface;
+use Psr\Http\Message\StreamInterface as PsrStreamInterface;
+use RuntimeException;
 
-class Stream implements \Psr\Http\Message\StreamInterface
+class Stream implements PsrStreamInterface
 {
     /**
-     * @var \Icicle\Stream\ReadableStreamInterface
+     * @var \Icicle\Stream\StreamInterface
      */
     private $stream;
 
-    public function __construct(ReadableStreamInterface $stream)
+    public function __construct(StreamInterface $stream)
     {
         $this->stream = $stream;
     }
@@ -21,10 +24,14 @@ class Stream implements \Psr\Http\Message\StreamInterface
     // @todo Implement other interface methods.
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function read($length)
     {
+        if (!$this->isReadable()) {
+            throw new RuntimeException('Stream is not readable');
+        }
+
         $promise = $this->stream->read($length);
 
         while ($promise->isPending()) {
@@ -34,19 +41,19 @@ class Stream implements \Psr\Http\Message\StreamInterface
         $result = $promise->getResult();
 
         if ($promise->isRejected()) {
-            throw $result; // May need to wrap Exception to be PSR-7 compliant?
+            new RuntimeException('Error reading from stream', 0, $result);
         }
 
         return $result;
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function write($data)
     {
-        if (!$this->stream instanceof WritableStreamInterface) {
-            throw new LogicException('Stream is not writable.'); // Can this throw? What else could it do?
+        if (!$this->isWritable()) {
+            throw new RuntimeException('Stream is not writable');
         }
 
         $promise = $this->stream->write($data);
@@ -58,9 +65,117 @@ class Stream implements \Psr\Http\Message\StreamInterface
         $result = $promise->getResult();
 
         if ($promise->isRejected()) {
-            throw $result; // May need to wrap Exception to be PSR-7 compliant?
+            new RuntimeException('Error writing to stream', 0, $result);
         }
 
         return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        // TODO: Implement __toString() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        $this->stream->close();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function detach()
+    {
+        // TODO: Implement detach() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize()
+    {
+        // TODO: Implement getSize() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tell()
+    {
+        // TODO: Implement tell() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eof()
+    {
+        // TODO: Implement eof() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSeekable()
+    {
+        return ($this->stream instanceof SeekableStreamInterface);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        if (!$this->isSeekable()) {
+            throw new RuntimeException('Stream is not seekable');
+        }
+
+        // TODO: Implement seek() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        // TODO: Implement rewind() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable()
+    {
+        return ($this->stream instanceof WritableStreamInterface);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable()
+    {
+        return ($this->stream instanceof ReadableStreamInterface);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContents()
+    {
+        // TODO: Implement getContents() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($key = null)
+    {
+        // TODO: Implement getMetadata() method.
     }
 }

--- a/tests/Stream/StreamTest.php
+++ b/tests/Stream/StreamTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Icicle\Tests\Psr7Bridge;
+
+use Icicle\Promise\PromiseInterface;
+use Icicle\Loop;
+use Icicle\Psr7Bridge\Stream\Stream;
+use Icicle\Stream\ReadableStreamInterface;
+use Icicle\Stream\WritableStreamInterface;
+use PHPUnit_Framework_TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use RuntimeException;
+
+class StreamTest extends PHPUnit_Framework_TestCase
+{
+    public function testReadReturnsDataFromAsyncStream()
+    {
+        /** @var ObjectProphecy|ReadableStreamInterface $readableStream */
+        $readableStream = $this->prophesize(ReadableStreamInterface::class);
+
+        /** @var ObjectProphecy|PromiseInterface $promise */
+        $promise = $this->prophesize(PromiseInterface::class);
+        $promise->isPending()->willReturn(false);
+        $promise->getResult()->willReturn('ABCDEFGHIJ');
+        $promise->isRejected()->willReturn(false);
+
+        $readableStream->read(10)->willReturn($promise->reveal());
+
+        $stream = new Stream($readableStream->reveal());
+        $result = $stream->read(10);
+        $this->assertEquals('ABCDEFGHIJ', $result);
+    }
+
+    public function testReadThrowsExceptionWhenStreamIsNotReadable()
+    {
+        /** @var ObjectProphecy|WritableStreamInterface $notReadableStream */
+        $notReadableStream = $this->prophesize(WritableStreamInterface::class);
+
+        $stream = new Stream($notReadableStream->reveal());
+        $this->setExpectedException(RuntimeException::class);
+        $stream->read(10);
+    }
+
+    public function testWriteSendsDataToAsyncStream()
+    {
+        /** @var ObjectProphecy|WritableStreamInterface $readableStream */
+        $readableStream = $this->prophesize(WritableStreamInterface::class);
+
+        /** @var ObjectProphecy|PromiseInterface $promise */
+        $promise = $this->prophesize(PromiseInterface::class);
+        $promise->isPending()->willReturn(false);
+        $promise->getResult()->willReturn(10);
+        $promise->isRejected()->willReturn(false);
+
+        $readableStream->write('ABCDEFGHIJ')->willReturn($promise->reveal());
+
+        $stream = new Stream($readableStream->reveal());
+        $result = $stream->write('ABCDEFGHIJ');
+        $this->assertEquals(10, $result);
+    }
+
+    public function testWriteThrowsExceptionWhenStreamIsNotWritable()
+    {
+        /** @var ObjectProphecy|ReadableStreamInterface $notWritableStream */
+        $notWritableStream = $this->prophesize(ReadableStreamInterface::class);
+
+        $stream = new Stream($notWritableStream->reveal());
+        $this->setExpectedException(RuntimeException::class);
+        $stream->write("XYZ");
+    }
+}


### PR DESCRIPTION
Here's my first PR. I will send my code in small chunks, at least in the beginning - at first I want to establish basic workflow, and agree on some patterns that we can follow later.

At this moment I have two elements to discuss.
1. exceptions thrown from `read` and `write`

I made exceptions thrown compatible with PSR7 spec - `RuntimeException`s are thrown if stream is not readable/writable, or when operation fails. I don't want to lose orignal exception (it can inform about exact reason for failure), so I'm passing it as "previous exception". Is it OK?
1. Loop and blocking

`read` and `write` are using following code to wait until data is ready:

``` php
while ($promise->isPending()) {
    Loop\tick(true);
}
```

This is blocking whole application, right? Can I unit test it then?
Or maybe (could be a stupid question), is something like this possible:

``` php
Loop\do_other_async_stuff_until_promise_is_done($promise);
```

?
