### PR TITLE
More StreamInterface functions

### DIFF
--- a/src/Stream/Stream.php
+++ b/src/Stream/Stream.php
@@ -21,8 +21,6 @@ class Stream implements PsrStreamInterface
         $this->stream = $stream;
     }
 
-    // @todo Implement other interface methods.
-
     /**
      * {@inheritdoc}
      */
@@ -41,7 +39,7 @@ class Stream implements PsrStreamInterface
         $result = $promise->getResult();
 
         if ($promise->isRejected()) {
-            new RuntimeException('Error reading from stream', 0, $result);
+            throw new RuntimeException('Error reading from stream', 0, $result);
         }
 
         return $result;
@@ -65,7 +63,7 @@ class Stream implements PsrStreamInterface
         $result = $promise->getResult();
 
         if ($promise->isRejected()) {
-            new RuntimeException('Error writing to stream', 0, $result);
+            throw new RuntimeException('Error writing to stream', 0, $result);
         }
 
         return $result;
@@ -76,7 +74,7 @@ class Stream implements PsrStreamInterface
      */
     public function __toString()
     {
-        // TODO: Implement __toString() method.
+
     }
 
     /**
@@ -100,7 +98,10 @@ class Stream implements PsrStreamInterface
      */
     public function getSize()
     {
-        // TODO: Implement getSize() method.
+        if ($this->stream instanceof SeekableStreamInterface) {
+            return $this->stream->getLength();
+        }
+        return null;
     }
 
     /**
@@ -108,7 +109,10 @@ class Stream implements PsrStreamInterface
      */
     public function tell()
     {
-        // TODO: Implement tell() method.
+        if ($this->stream instanceof SeekableStreamInterface) {
+            return $this->stream->tell();
+        }
+        return null;
     }
 
     /**
@@ -176,6 +180,9 @@ class Stream implements PsrStreamInterface
      */
     public function getMetadata($key = null)
     {
-        // TODO: Implement getMetadata() method.
+        if (null === $key) {
+            return [];
+        }
+        return null;
     }
 }

--- a/src/Stream/Stream.php
+++ b/src/Stream/Stream.php
@@ -140,7 +140,16 @@ class Stream implements PsrStreamInterface
             throw new RuntimeException('Stream is not seekable');
         }
 
-        // TODO: Implement seek() method.
+        $promise = $this->stream->seek($offset, $whence);
+
+        while ($promise->isPending()) {
+            Loop\tick(true);
+        }
+
+        if ($promise->isRejected()) {
+            $result = $promise->getResult();
+            throw new RuntimeException('Error seeking stream', 0, $result);
+        }
     }
 
     /**
@@ -148,7 +157,7 @@ class Stream implements PsrStreamInterface
      */
     public function rewind()
     {
-        // TODO: Implement rewind() method.
+        $this->seek(0);
     }
 
     /**


### PR DESCRIPTION
I'm getting back with more methods of `StreamInterface`. I'm a bit unsure with what to do with remaining ones. `eof`: does it make any sense for socket streams? `getContents` and `toString` could be implemented using `while ($this->stream->isReadable())`, but does it make sense at all?
