### PR TITLE
Finish testsuite for Stream

### DIFF
--- a/src/Stream/Stream.php
+++ b/src/Stream/Stream.php
@@ -141,7 +141,7 @@ class Stream implements PsrStreamInterface
      */
     public function eof()
     {
-        return $this->isReadable() && $this->stream->isReadable();
+        return !$this->isReadable() || !$this->stream->isReadable();
     }
 
     /**

--- a/tests/Stream/StreamTest.php
+++ b/tests/Stream/StreamTest.php
@@ -319,21 +319,21 @@ class StreamTest extends TestCase
         $this->assertEquals('RESOURCE', $stream->detach());
     }
 
-//    public function testEofReturnsFalseWhenStreamAndWrappedStreamAreReadable()
-//    {
-//        /** @var ObjectProphecy|ReadableStreamInterface $readableStream */
-//        $readableStream = $this->prophesize(ReadableStreamInterface::class);
-//        $readableStream->isReadable()->willReturn(true);
-//        $stream = new Stream($readableStream->reveal());
-//        $this->assertFalse($stream->eof());
-//    }
-//
-//    public function testEofReturnsFalseWhenStreamOrWrappedStreamAreNotReadable()
-//    {
-//        /** @var ObjectProphecy|ReadableStreamInterface $readableStream */
-//        $readableStream = $this->prophesize(ReadableStreamInterface::class);
-//        $readableStream->isReadable()->willReturn(false);
-//        $stream = new Stream($readableStream->reveal());
-//        $this->assertTrue($stream->eof());
-//    }
+    public function testEofReturnsFalseWhenStreamAndWrappedStreamAreReadable()
+    {
+        /** @var ObjectProphecy|ReadableStreamInterface $readableStream */
+        $readableStream = $this->prophesize(ReadableStreamInterface::class);
+        $readableStream->isReadable()->willReturn(true);
+        $stream = new Stream($readableStream->reveal());
+        $this->assertFalse($stream->eof());
+    }
+
+    public function testEofReturnsFalseWhenStreamOrWrappedStreamAreNotReadable()
+    {
+        /** @var ObjectProphecy|ReadableStreamInterface $readableStream */
+        $readableStream = $this->prophesize(ReadableStreamInterface::class);
+        $readableStream->isReadable()->willReturn(false);
+        $stream = new Stream($readableStream->reveal());
+        $this->assertTrue($stream->eof());
+    }
 }


### PR DESCRIPTION
- fixed bug with `eof()`
- almost 100% test coverage

I also rewrote tests back to Prophecy, discovering interesting fact - you simply cannot use static variables in callback like this:

``` php
$promise->isPending()->will(function () {
            static $pending = true;
            if ($pending) {
                // Schedule a function to simulate an event that resolves the promise.
                Loop\schedule(function () use (&$pending) {
                    $pending = false;
                });
            }
            return $pending;
        });
```

This is because Prophecy binds closure, which apparently creates new one, with "fresh" static vars:

``` php
if ($callback instanceof Closure && method_exists('Closure', 'bind')) {
            $callback = Closure::bind($callback, $object);
        }

        return call_user_func($callback, $args, $object, $method);
```

In order to fix this issue, I have to use variable from one scope above.
