### PR TITLE
RFC: message factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "icicleio/http": "dev-master",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "zendframework/zend-diactoros": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.6"

--- a/src/MessageFactory.php
+++ b/src/MessageFactory.php
@@ -22,25 +22,33 @@ final class MessageFactory implements MessageFactoryInterface
     }
 
     /**
-     * @param IcicleRequest $request
+     * @param IcicleRequest $icicleRequest
      * @return PsrRequest
      */
-    public function createRequest(IcicleRequest $request)
+    public function createRequest(IcicleRequest $icicleRequest)
     {
-        return new PsrRequest(
-            $this->createUri($request->getUri()),
-            $request->getMethod(),
-            new Stream($request->getBody()),
-            $request->getHeaders()
+        $request = new PsrRequest(
+            $this->createUri($icicleRequest->getUri()),
+            $icicleRequest->getMethod(),
+            new Stream($icicleRequest->getBody()),
+            $icicleRequest->getHeaders()
         );
+
+        $request = $request->withProtocolVersion($icicleRequest->getProtocolVersion());
+
+        return $request;
     }
 
-    public function createResponse(IcicleResponse $response)
+    public function createResponse(IcicleResponse $icicleResponse)
     {
-        return new PsrResponse(
-            new Stream($response->getBody()),
-            $response->getStatusCode(),
-            $response->getHeaders()
+        $response = new PsrResponse(
+            new Stream($icicleResponse->getBody()),
+            $icicleResponse->getStatusCode(),
+            $icicleResponse->getHeaders()
         );
+
+        $response = $response->withProtocolVersion($icicleResponse->getProtocolVersion());
+
+        return $response;
     }
 }

--- a/src/MessageFactory.php
+++ b/src/MessageFactory.php
@@ -10,13 +10,13 @@ use Zend\Diactoros\Uri as PsrUri;
 use Zend\Diactoros\Request as PsrRequest;
 use Zend\Diactoros\Response as PsrResponse;
 
-class MessageFactory
+final class MessageFactory implements MessageFactoryInterface
 {
     /**
      * @param IcicleUri $icicleUri
      * @return PsrUri
      */
-    public static function createUri(IcicleUri $icicleUri)
+    public function createUri(IcicleUri $icicleUri)
     {
         return new PsrUri($icicleUri->__toString());
     }
@@ -25,17 +25,17 @@ class MessageFactory
      * @param IcicleRequest $request
      * @return PsrRequest
      */
-    public static function createRequest(IcicleRequest $request)
+    public function createRequest(IcicleRequest $request)
     {
         return new PsrRequest(
-            static::createUri($request->getUri()),
+            $this->createUri($request->getUri()),
             $request->getMethod(),
             new Stream($request->getBody()),
             $request->getHeaders()
         );
     }
 
-    public static function createResponse(IcicleResponse $response)
+    public function createResponse(IcicleResponse $response)
     {
         return new PsrResponse(
             new Stream($response->getBody()),

--- a/src/MessageFactory.php
+++ b/src/MessageFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Icicle\Psr7Bridge;
+
+use Icicle\Http\Message\RequestInterface as IcicleRequest;
+use Icicle\Http\Message\ResponseInterface as IcicleResponse;
+use Icicle\Http\Message\UriInterface as IcicleUri;
+use Icicle\Psr7Bridge\Stream\Stream;
+use Zend\Diactoros\Uri as PsrUri;
+use Zend\Diactoros\Request as PsrRequest;
+use Zend\Diactoros\Response as PsrResponse;
+
+class MessageFactory
+{
+    /**
+     * @param IcicleUri $icicleUri
+     * @return PsrUri
+     */
+    public static function createUri(IcicleUri $icicleUri)
+    {
+        return new PsrUri($icicleUri->__toString());
+    }
+
+    /**
+     * @param IcicleRequest $request
+     * @return PsrRequest
+     */
+    public static function createRequest(IcicleRequest $request)
+    {
+        return new PsrRequest(
+            static::createUri($request->getUri()),
+            $request->getMethod(),
+            new Stream($request->getBody()),
+            $request->getHeaders()
+        );
+    }
+
+    public static function createResponse(IcicleResponse $response)
+    {
+        return new PsrResponse(
+            new Stream($response->getBody()),
+            $response->getStatusCode(),
+            $response->getHeaders()
+        );
+    }
+}

--- a/src/MessageFactoryInterface.php
+++ b/src/MessageFactoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Icicle\Psr7Bridge;
+
+use Icicle\Http\Message\RequestInterface as IcicleRequest;
+use Icicle\Http\Message\ResponseInterface as IcicleResponse;
+use Icicle\Http\Message\UriInterface as IcicleUri;
+use Zend\Diactoros\Request as PsrRequest;
+use Zend\Diactoros\Uri as PsrUri;
+
+interface MessageFactoryInterface
+{
+    /**
+     * @param IcicleUri $icicleUri
+     * @return PsrUri
+     */
+    public function createUri(IcicleUri $icicleUri);
+
+    /**
+     * @param IcicleRequest $request
+     * @return PsrRequest
+     */
+    public function createRequest(IcicleRequest $request);
+
+    public function createResponse(IcicleResponse $response);
+}

--- a/tests/MessageFactoryTest.php
+++ b/tests/MessageFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Icicle\Tests\Psr7Bridge;
+
+use Icicle\Http\Message\Request as IcicleRequest;
+use Icicle\Http\Message\Uri as IcicleUri;
+use Icicle\Psr7Bridge\MessageFactory;
+use Icicle\Stream\ReadableStreamInterface;
+use PHPUnit_Framework_TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface as PsrStream;
+use Psr\Http\Message\UriInterface;
+
+class MessageFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MessageFactory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->factory = new MessageFactory();
+    }
+
+    public function testCreateUri()
+    {
+        $stringUri = "http://johndoe:PWD@www.website.net/some/path/";
+        $icicleUri = new IcicleUri($stringUri);
+        $psrUri = $this->factory->createUri($icicleUri);
+        $this->assertInstanceOf(UriInterface::class, $psrUri);
+        $this->assertEquals($stringUri, $psrUri->__toString());
+    }
+
+    public function testCreateRequest()
+    {
+        $stringUri = "http://johndoe:PWD@www.website.net/some/path/";
+        $headers = [
+            'Host' => ['www.website.net'],
+            'X-Forwarded-For' => ['100.100.100.100,192.168.1.123'],
+            'Connection' => ['keep-alive'],
+            'Cache-Control' => ['max-age=0']
+        ];
+        $icicleStream = $this->prophesize(ReadableStreamInterface::class);
+        $icicleRequest = new IcicleRequest("GET", new IcicleUri($stringUri), $headers, $icicleStream->reveal());
+        $psrRequest = $this->factory->createRequest($icicleRequest);
+
+        $this->assertInstanceOf(RequestInterface::class, $psrRequest);
+        $this->assertEquals("GET", $psrRequest->getMethod());
+        $this->assertEquals($headers, $psrRequest->getHeaders());
+        $this->assertInstanceOf(PsrStream::class, $psrRequest->getBody());
+    }
+}

--- a/tests/Stream/StreamTest.php
+++ b/tests/Stream/StreamTest.php
@@ -6,7 +6,6 @@ use Exception;
 use Icicle\Promise\PromiseInterface;
 use Icicle\Loop;
 use Icicle\Psr7Bridge\Stream\Stream;
-use Icicle\Socket\Socket;
 use Icicle\Socket\Stream\WritableStream;
 use Icicle\Stream\ReadableStreamInterface;
 use Icicle\Stream\SeekableStreamInterface;


### PR DESCRIPTION
Hi Aaron,

When thinking what's the best way to implement PSR-7 compatible messages, I realized that once `Stream` is implemented, we can actually reuse existing PSR-7 library. See how this PR looks like - what do you think?
